### PR TITLE
Fix unasigned duration variables

### DIFF
--- a/ktb-history
+++ b/ktb-history
@@ -6,6 +6,7 @@ from argparse                           import ArgumentParser, RawDescriptionHel
 from lib.launchpad                      import Launchpad
 import lib.colored
 from datetime                           import datetime
+import csv 
 
 def pro(*args, **kwargs):
     print(*args, file=sys.stdout, **kwargs)
@@ -82,6 +83,12 @@ class LPBugHistory():
         delta = datetime.strptime(after, '%Y-%m-%d %H:%M:%S') - datetime.strptime(before, '%Y-%m-%d %H:%M:%S')
         return str(delta)
 
+    def save_stats(self,bug,buildtime,boottime,srutime,newreviewtime,proposedtime,certtime,attime,rttime,updatestime):
+        data = [bug.id,bug.title,buildtime,boottime,srutime,newreviewtime,proposedtime,certtime,attime,rttime,updatestime]
+        with open('output.csv','a',newline='') as file:
+            writer = csv.writer(file)
+            writer.writerow(data)
+
     # __verbose_bug_info
     #
     def __print_bug_info(self, bug):
@@ -102,6 +109,8 @@ class LPBugHistory():
         history = bug.activity
         prev_timestamp = None
         lineno = 0
+        buildtime=boottime=srutime=newreviewtime=proposedtime=certtime=attime=rttime=updatestime = "Empty"
+
         for activity in history:
             if activity.whatchanged.endswith('status'):
                 lineno += 1
@@ -163,6 +172,7 @@ class LPBugHistory():
                             duration = '(' + self.duration(build_start, timestamp) + ')'
                         except NameError:
                             duration = '(Invalid)'
+                        buildtime = duration
                         o += anno_r(clr_build, 'build finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_bt, 'boot-testing started  ')
@@ -175,7 +185,7 @@ class LPBugHistory():
                         o += anno_r(clr_bt, 'boot-testing finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
-
+                        boottime = duration
                     case 'promote-to-proposed:Fix Released':                          # -proposed
                         try:
                             duration = '(' + self.duration(crank_start, timestamp) + ')'
@@ -184,6 +194,7 @@ class LPBugHistory():
                         o += anno_r(clr_proposed, '-proposed promotion finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
+                        proposedtime = duration
 
                     case 'promote-to-updates:Fix Released':                           # -updates
                         try:
@@ -193,6 +204,7 @@ class LPBugHistory():
                         o += anno_r(clr_updates, '-updates promotion finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
+                        updatestime=duration
 
                     case 'regression-testing:Incomplete':
                         regression_testing_start = timestamp
@@ -208,6 +220,7 @@ class LPBugHistory():
                         o += anno_r(clr_testing, 'regression testing finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
+                        rttime=duration
 
                     case 'certification-testing:Opinion':
                         certification_testing_start = timestamp
@@ -223,6 +236,7 @@ class LPBugHistory():
                         o += anno_r(clr_testing, 'certification testing finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
+                        certtime=duration
 
                     case 'automated-testing:Incomplete':
                         automated_testing_start = timestamp
@@ -238,6 +252,7 @@ class LPBugHistory():
                         o += anno_r(clr_testing, 'automated testing finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
+                        attime=duration
 
                     case ('sru-review:Triaged' | 'sru-review:Confirmed'):
                         sru_review_ready = timestamp
@@ -253,6 +268,7 @@ class LPBugHistory():
                         o += anno_r(clr_sru, 'sru review finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
+                        srutime = duration
 
                     case 'new-review:Triaged':
                         new_review_ready = timestamp
@@ -268,6 +284,7 @@ class LPBugHistory():
                         o += anno_r(clr_sru, 'new review finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
+                        newreviewtime = duration
 
                     case 'signing-signoff:Confirmed':
                         signing_start = timestamp
@@ -290,6 +307,8 @@ class LPBugHistory():
                         o += anno_r(clr_default, ' ')
 
                 pro(o)
+        self.save_stats(bug,buildtime,boottime,srutime,newreviewtime,proposedtime,certtime,attime,rttime,updatestime)
+
 
     # main
     #

--- a/ktb-history
+++ b/ktb-history
@@ -143,7 +143,10 @@ class LPBugHistory():
                         o += anno_r(clr_default, ' ')
 
                     case 'prepare-package:Fix Released':                              # crank finished
-                        duration = '(' + self.duration(crank_start, timestamp) + ')'
+                        try:
+                            duration = '(' + self.duration(crank_start, timestamp) + ')'
+                        except NameError:
+                            duration = '(Invalid)'
                         o += anno_r(clr_crank, 'crank finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
@@ -156,25 +159,37 @@ class LPBugHistory():
 
                     case 'boot-testing:Triaged':                                      # build finished & boot testing started
                         boot_testing_start = timestamp
-                        duration = '(' + self.duration(build_start, timestamp) + ')'
+                        try:
+                            duration = '(' + self.duration(build_start, timestamp) + ')'
+                        except NameError:
+                            duration = '(Invalid)'
                         o += anno_r(clr_build, 'build finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_bt, 'boot-testing started  ')
 
                     case 'boot-testing:Fix Released':                                 # boot testing finished
-                        duration = '(' + self.duration(boot_testing_start, timestamp) + ')'
+                        try:
+                            duration = '(' + self.duration(boot_testing_start, timestamp) + ')'
+                        except NameError:
+                            duration = '(Invalid)'
                         o += anno_r(clr_bt, 'boot-testing finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
 
                     case 'promote-to-proposed:Fix Released':                          # -proposed
-                        duration = '(' + self.duration(crank_start, timestamp) + ')'
+                        try:
+                            duration = '(' + self.duration(crank_start, timestamp) + ')'
+                        except NameError:
+                            duration = '(Invalid)'
                         o += anno_r(clr_proposed, '-proposed promotion finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
 
                     case 'promote-to-updates:Fix Released':                           # -updates
-                        duration = '(' + self.duration(crank_start, timestamp) + ')'
+                        try:
+                            duration = '(' + self.duration(crank_start, timestamp) + ')'
+                        except NameError:
+                            duration = '(Invalid)'
                         o += anno_r(clr_updates, '-updates promotion finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
@@ -186,7 +201,10 @@ class LPBugHistory():
                         o += anno_r(clr_default, ' ')
 
                     case 'regression-testing:Fix Released':
-                        duration = '(' + self.duration(regression_testing_start, timestamp) + ')'
+                        try:
+                            duration = '(' + self.duration(regression_testing_start, timestamp) + ')'
+                        except NameError:
+                            duration = '(Invalid)'
                         o += anno_r(clr_testing, 'regression testing finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
@@ -198,7 +216,10 @@ class LPBugHistory():
                         o += anno_r(clr_default, ' ')
 
                     case 'certification-testing:Fix Released':
-                        duration = '(' + self.duration(certification_testing_start, timestamp) + ')'
+                        try:
+                            duration = '(' + self.duration(certification_testing_start, timestamp) + ')'
+                        except NameError:
+                            duration = '(Invalid)'
                         o += anno_r(clr_testing, 'certification testing finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
@@ -210,7 +231,10 @@ class LPBugHistory():
                         o += anno_r(clr_default, ' ')
 
                     case 'automated-testing:Fix Released':
-                        duration = '(' + self.duration(automated_testing_start, timestamp) + ')'
+                        try:
+                            duration = '(' + self.duration(automated_testing_start, timestamp) + ')'
+                        except NameError:
+                            duration = '(Invalid)'
                         o += anno_r(clr_testing, 'automated testing finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
@@ -222,7 +246,10 @@ class LPBugHistory():
                         o += anno_r(clr_default, ' ')
 
                     case 'sru-review:Fix Released':
-                        duration = '(' + self.duration(sru_review_ready, timestamp) + ')'
+                        try:
+                            duration = '(' + self.duration(sru_review_ready, timestamp) + ')'
+                        except NameError:
+                            duration = '(Invalid)'
                         o += anno_r(clr_sru, 'sru review finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
@@ -234,7 +261,10 @@ class LPBugHistory():
                         o += anno_r(clr_default, ' ')
 
                     case 'new-review:Fix Released':
-                        duration = '(' + self.duration(new_review_ready, timestamp) + ')'
+                        try:
+                            duration = '(' + self.duration(new_review_ready, timestamp) + ')'
+                        except NameError:
+                            duration = '(Invalid)'
                         o += anno_r(clr_sru, 'new review finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')
@@ -246,7 +276,10 @@ class LPBugHistory():
                         o += anno_r(clr_default, ' ')
 
                     case 'signing-signoff:Fix Released':
-                        duration = '(' + self.duration(signing_start, timestamp) + ')'
+                        try:
+                            duration = '(' + self.duration(signing_start, timestamp) + ')'
+                        except NameError:
+                            duration = '(Invalid)'
                         o += anno_r(clr_signing, 'signing finished  ')
                         o += anno_d(duration)
                         o += anno_r(clr_default, ' ')


### PR DESCRIPTION
When dealing with tracking bugs that were manually bypassed, the previous timestamp didnt exist and thus gave an exception